### PR TITLE
Update pip for SCons installation on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,8 @@ environment:
 
 install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - pip install --egg scons  # it will fail on AppVeyor without --egg flag
+  - pip --version
+  - pip install scons  # it will fail on AppVeyor without --egg flag
   - if defined VS call "%VS%" %ARCH%  # if defined - so we can also use mingw
   - git submodule update --init --recursive # download submodules
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,11 @@ environment:
 
 install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # update pip to latest version, because 7.1.2 is problematic
+  # see https://github.com/GodotBuilder/godot-builds/pull/2
+  - python -m pip install --upgrade pip
   - pip --version
-  - pip install scons  # it will fail on AppVeyor without --egg flag
+  - pip install scons
   - if defined VS call "%VS%" %ARCH%  # if defined - so we can also use mingw
   - git submodule update --init --recursive # download submodules
 


### PR DESCRIPTION
Python 2.7.11 seems to ship with pip 7.1.2, which fails to `pip install scons`:

```
pip --version
pip 7.1.2 from c:\python27\lib\site-packages (python 2.7)
pip install scons
Collecting scons
  Downloading scons-2.5.0.tar.gz (620kB)
Installing collected packages: scons
  Running setup.py install for scons
    Complete output from command c:\python27\python.exe -c "import setuptools, tokenize;__file__='c:\\users\\appveyor\\appdata\\local\\temp\\1\\pip-build-g7cqps\\scons\\setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record c:\users\appveyor\appdata\local\temp\1\pip-a8r4ou-record\install-record.txt --single-version-externally-managed --compile:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: option --single-version-externally-managed not recognized

    ----------------------------------------
Command "c:\python27\python.exe -c "import setuptools, tokenize;__file__='c:\\users\\appveyor\\appdata\\local\\temp\\1\\pip-build-g7cqps\\scons\\setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record c:\users\appveyor\appdata\local\temp\1\pip-a8r4ou-record\install-record.txt --single-version-externally-managed --compile" failed with error code 1 in c:\users\appveyor\appdata\local\temp\1\pip-build-g7cqps\scons
You are using pip version 7.1.2, however version 8.1.1 is available.
You should consider upgrading via the 'python -m pip install --upgrade pip' command.
Command exited with code 1
```

https://ci.appveyor.com/project/GodotBuilder/godot-builds/build/1.0.3/job/99s7raxfmm780i3s#L7

The solution is to upgrade pip to latest version before installing `scons`.
