### PR TITLE
Build WebAssembly, use latest Emscripten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ env:
   matrix:
     - PLATFORM=iphone TARGET=release
     - PLATFORM=iphone TARGET=release_debug
-    - PLATFORM=javascript TARGET=release
-    - PLATFORM=javascript TARGET=release_debug
+    - PLATFORM=javascript WASM=no TARGET=release
+    - PLATFORM=javascript WASM=no TARGET=release_debug
+    - PLATFORM=javascript WASM=yes TARGET=release
+    - PLATFORM=javascript WASM=yes TARGET=release_debug
     - PLATFORM=osx BITS=fat TOOLS=yes TARGET=release_debug
     - PLATFORM=osx BITS=fat TOOLS=no TARGET=release
     - PLATFORM=osx BITS=fat TOOLS=no TARGET=release_debug
@@ -56,9 +58,13 @@ matrix:
     - os: linux
       env: PLATFORM=iphone TARGET=release_debug
     - os: linux
-      env: PLATFORM=javascript TARGET=release
+      env: PLATFORM=javascript WASM=no TARGET=release
     - os: linux
-      env: PLATFORM=javascript TARGET=release_debug
+      env: PLATFORM=javascript WASM=no TARGET=release_debug
+    - os: linux
+      env: PLATFORM=javascript WASM=yes TARGET=release
+    - os: linux
+      env: PLATFORM=javascript WASM=yes TARGET=release_debug
     - os: linux
       env: PLATFORM=osx BITS=fat TOOLS=yes TARGET=release_debug
     - os: linux
@@ -80,9 +86,13 @@ matrix:
     - compiler: gcc
       env: PLATFORM=iphone TARGET=release_debug
     - compiler: gcc
-      env: PLATFORM=javascript TARGET=release
+      env: PLATFORM=javascript WASM=no TARGET=release
     - compiler: gcc
-      env: PLATFORM=javascript TARGET=release_debug
+      env: PLATFORM=javascript WASM=no TARGET=release_debug
+    - compiler: gcc
+      env: PLATFORM=javascript WASM=yes TARGET=release
+    - compiler: gcc
+      env: PLATFORM=javascript WASM=yes TARGET=release_debug
     - compiler: gcc
       env: PLATFORM=osx BITS=fat TOOLS=yes TARGET=release_debug
     - compiler: gcc
@@ -129,9 +139,12 @@ before_script:
       fi;
     fi;
   - if [ "$PLATFORM" = "javascript" ]; then
-      brew update; brew install -v scons emscripten;
-      emcc; sed -i "" s/^LLVM_ROOT.*/LLVM_ROOT='"\/usr\/local\/opt\/emscripten\/libexec\/llvm\/bin\/"'/ "$HOME/.emscripten";
-      sed -i "" "/^BINARYEN_ROOT.*/d" "$HOME/.emscripten";
+      cd $HOME;
+      wget https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz;
+      tar -xzf emsdk-portable.tar.gz;
+      cd emsdk-portable; ./emsdk update; ./emsdk install latest; ./emsdk activate latest;
+      source ./emsdk_env.sh;
+      cd $TRAVIS_BUILD_DIR;
       export EMSCRIPTEN_ROOT=`em-config EMSCRIPTEN_ROOT`;
     fi;
 
@@ -155,7 +168,7 @@ script:
       scons -j2 platform=$PLATFORM CXX=$CXX $OPTIONS arch=arm64 target=$TARGET;
     fi;
   - if [ "$PLATFORM" = "javascript" ]; then
-      scons -j2 platform=$PLATFORM CXX=$CXX $OPTIONS target=$TARGET;
+      scons -j2 platform=$PLATFORM wasm=$WASM CXX=$CXX $OPTIONS target=$TARGET;
     fi;
 
 
@@ -167,6 +180,8 @@ before_deploy:
     fi;
   - if [ "$PLATFORM" = "javascript" ]; then
       if [ "$TARGET" = "release" ]; then target_tag="opt"; else target_tag="opt.debug"; fi;
+      if [ "$WASM" = "yes" ]; then target_tag=target_tag+".webassembly"; fi;
+      rm -f bin/godot.javascript.$target_tag.wasm;
       rm -f bin/godot.javascript.$target_tag.asm.js;
       rm -f bin/godot.javascript.$target_tag.js;
       rm -f bin/godot.javascript.$target_tag.html*;


### PR DESCRIPTION
This downloads emsdk and uses that to install up-to-date Emscripten, which enables us to build WebAssembly templates