### PR TITLE
Add build of gdnative_wrapper static library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
   global:
 #    - BUILD_NAME=official
     - BUILD_NAME=build1
-    - OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes"
+    - OPTIONS="builtin_libpng=yes builtin_openssl=yes builtin_zlib=yes gdnative_wrapper=yes"
     - SCONS="scons -j2 verbose=yes warnings=no progress=no"
   matrix:
     - PLATFORM=iphone TARGET=release
@@ -223,6 +223,7 @@ deploy:
   file_glob: true
   file:
     - bin/*godot*.$PLATFORM.opt.*
+    - bin/*gdnative_wrapper_code*.$PLATFORM.opt.*
   skip_cleanup: true
   on:
     repo: GodotBuilder/godot-builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ skip_non_tags: true
 artifacts:
   - path: godot\bin\*.exe
     name: GodotBinary
+  - path: godot\bin\*.dll
+    name: GodotGDNativeWrapper
 
 environment:
 #  BUILD_NAME: official
@@ -85,13 +87,15 @@ build_script:
   - cd godot
   - for /f %%p in ('dir /b ..\patches') do git apply ..\patches\%%p
   - git rev-parse HEAD
-  - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% progress=no
+  - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% progress=no  gdnative_wrapper=yes
 
 deploy:
   description: 'Godot binaries deployed by Travis CI and AppVeyor'
   provider: GitHub
   auth_token:
     secure: DYTTAkQFPIDq2YL6hPMOttlHdJ9ZL6dYdOtGFIEneO8BTYx6keJRvewsdzgP2QGA
-  artifact: GodotBinary
+  artifact:
+    - GodotBinary
+    - GodotGDNativeWrapper
   on:
     appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_non_tags: true
 artifacts:
   - path: godot\bin\*.exe
     name: GodotBinary
-  - path: godot\bin\*.dll
+  - path: godot\bin\*gdnative_wrapper_code*.dll
     name: GodotGDNativeWrapper
 
 environment:


### PR DESCRIPTION
Not 100% sure about this PR (I've never used appveyor for instance ^^)

The key point is this gdnative wrapper library is needed (strictly speaking you could do without it, but it's much more of a pita...) for any extension willing to use gdnative.
Given we are getting closer of 3.0, I'd like to release a pre-version of godot-python to beta testers to give us a much better confidence toward gdnative and pluginscript api and stability. This would be a lot easier to do with those gdnative wrapper already compiled for all the architectures (I still have to compile&package CPython and/or Pypy, which is enough of pain for me already ^^)